### PR TITLE
Code I added to ReportHtml

### DIFF
--- a/Private/Format-AnchorTag.ps1
+++ b/Private/Format-AnchorTag.ps1
@@ -1,0 +1,39 @@
+function Format-AnchorTag {
+    param (
+        $Object
+    )
+    
+    $AnchorTag = ''
+    try {        
+        $href = $Object.url
+        if($null -eq $href)
+        {
+            throw "Missing parameter 'url' (href)"
+        }
+        # using default target if none is set
+        $target = '_self'
+        if($null -ne $Object.target)
+        {
+            $target = $Object.target
+        }
+        
+        # using url if no content is set
+        $Content = $href
+        if($null -ne $Object.Content)
+        {
+            $Content = $Object.Content
+            if($Content -is [System.Management.Automation.PSCustomObject])
+            {
+                # could be an image
+                $Content = Format-Html -Object $Content
+            }
+        }
+
+        $AnchorTag = '<a href="{0}" target="{1}">{2}</a>' -f $href, $target, $Content     
+    }
+    catch {
+        Write-Warning "Failed to format anchor tag, error was $_"
+    }
+
+    $AnchorTag
+}

--- a/Private/Format-Html.ps1
+++ b/Private/Format-Html.ps1
@@ -1,0 +1,13 @@
+function Format-Html {
+    param (
+        $Object
+    )
+
+    switch ($Object) {
+        {$_._type -eq 'img'} { Format-ImageTag -Object $Object}
+        {$_._type -eq 'link'} { Format-AnchorTag -Object $Object }
+        Default {
+            throw "Unknown type, $($_._type)"
+        }
+    }    
+}

--- a/Private/Format-ImageTag.ps1
+++ b/Private/Format-ImageTag.ps1
@@ -1,0 +1,36 @@
+function Format-ImageTag {
+    param (
+        $Object
+    )
+    
+    $imgtag = ''
+    try {
+        # ex. <img src="smiley.gif" alt="Smiley face" height="42" width="42">
+        $src = $Object.src
+        $alt = $Object.alt
+        [string]$width = $Object.width
+        [string]$height = $Object.height   
+
+        $imgtag = '<img src="{0}" alt="{1}" height="{2}" width="{3}">' -f $src, $alt, $width, $height
+
+        if([string]::IsNullOrEmpty($alt))
+        {
+            $imgtag = $imgtag -replace 'alt=""'
+        }
+
+        if([string]::IsNullOrEmpty($width))
+        {
+            $imgtag = $imgtag -replace 'width=""'
+        }        
+
+        if([string]::IsNullOrEmpty($height))
+        {
+            $imgtag = $imgtag -replace 'height=""'
+        }        
+    }
+    catch {
+        Write-Warning "Failed to format image tag, error was $_"
+    }
+
+    $imgtag
+}

--- a/Public/Get-HTMLLineChart.ps1
+++ b/Public/Get-HTMLLineChart.ps1
@@ -1,0 +1,97 @@
+Function Get-HTMLLineChart
+{
+<#
+	.SYNOPSIS
+	
+#>
+	[CmdletBinding()]
+	Param (
+		[Parameter(Mandatory=$true)]
+		$ChartObject,
+		[Parameter(Mandatory=$true)]
+		[Array]
+		$DataSet,
+		[Parameter(Mandatory=$false)]
+		$Options
+	)
+	
+	$DataCount = $ChartObject.DataDefinition.DataSetNames.Count
+	Write-Verbose "Data Set count is $DataCount"
+
+	if ($ChartObject.ChartStyle.ColorSchemeName -ne 'Random')
+	{
+		if ($null -eq $Options) {
+			$ChartColorScheme = $GlobalColorSchemes.($ChartObject.ChartStyle.ColorSchemeName) | Select-Object -First $DataCount
+		} else {
+			Write-Verbose "Options Colour Schemes selected, selecting $($ChartObject.ChartStyle.ColorSchemeName)"
+			$ChartColorScheme = $Options.ColorSchemes.($ChartObject.ChartStyle.ColorSchemeName) | Select-Object -First $DataCount
+		}
+		if ($ChartColorScheme.Count -lt $DataCount) {
+			Write-Warning ("Colorscheme " +  $ChartObject.ChartStyle.ColorSchemeName + " only has " + $ChartColorScheme.Count + " schemes, you have $DataCount Records. Generating one for you" )			
+			$ChartColorScheme = GenerateRandomColorScheme -numberofschemes $DataCount
+		}
+	}
+	else
+	{
+		$ChartColorScheme = GenerateRandomColorScheme -numberofschemes $DataCount
+	}
+
+	$Labels = ""
+	if($ChartObject.ChartStyle.Showlabels)
+	{
+		$Labels= '		labels: [{0}],' -f ($DataSet.($ChartObject.DataDefinition.DataCategoryName) -join ',')
+	}
+	$ChartObjectObjectName = $ChartObject.ObjectName
+	# to display the title or not
+	$displayTitle = ([string](-not [string]::IsNullOrEmpty($ChartObject.Title))).tolower()
+
+	# a template for the dataset, notice we escape the {}
+	$sDataset = @'
+	{{
+		label: '{0}',
+		data: [{1}],
+		borderColor: '{2}',
+		borderWidth: {3}
+	}}
+'@
+
+	$CJS = @"
+	<canvas id="$ChartObjectObjectName" width="$($ChartObject.Size.Width)" height="$($ChartObject.Size.Height)"></canvas>
+	<script>
+	var ctx = document.getElementById("$ChartObjectObjectName");
+	var $ChartObjectObjectName = new Chart(ctx, {
+		type: '$($ChartObject.ChartStyle.ChartType)',
+		data:	{
+			$Labels
+			datasets: [
+				$(
+					$i = 0
+					($ChartObject.DataDefinition.DataSetNames | ForEach-Object {
+						$data = $DataSet.$_ -join ','
+						$sDataset -f $_, $data, $ChartColorScheme.border[$i], $ChartObject.ChartStyle.borderWidth
+						$i += 1
+					}) -join ','
+					
+				)				
+			]
+		},
+		options: {
+			responsive: $($ChartObject.ChartStyle.responsive),
+			legend: {
+					position: '$($ChartObject.ChartStyle.legendposition)',
+				},
+			title: {
+					display: $displayTitle,
+					text: '$($ChartObject.Title)'
+				},
+		},
+		animation: {
+					animateScale: $($ChartObject.ChartStyle.animateScale),
+					animateRotate: $($ChartObject.ChartStyle.animateRotate)
+				}
+	});	
+	</script>
+"@	
+
+	write-output $CJS
+}

--- a/Public/Get-HTMLLineChartObject.ps1
+++ b/Public/Get-HTMLLineChartObject.ps1
@@ -1,0 +1,67 @@
+Function Get-HTMLLineChartObject
+{
+<#
+	.SYNOPSIS
+		create a Line chart object for use with Get-HTMLLineChart
+#>
+    [CmdletBinding()]
+    param(
+		[ValidateSet("line")]
+		[String]
+		$ChartType = 'line',
+		[Parameter(Mandatory=$false)]
+		$ColorScheme,
+		[Parameter(Mandatory=$false)]
+		[int]$Width = 500,
+		[Parameter(Mandatory=$false)]
+		[int]$Height = 400,
+		[Parameter(Mandatory=$false)]
+		[string]$DataCategoryName = 'x',
+		[Parameter(Mandatory=$false)]
+		[string]$DataSetName = 'y',
+		[Parameter(Mandatory=$false)]
+		[Array]$DataSetNames = @()
+	)
+
+	$ChartSize = New-Object PSObject -Property @{`
+		Width = $Width
+		Height = $Height
+	}
+	
+	if($DataSetNames.Count -eq 0)
+	{
+		$DataSetNames = @($DataSetName)
+	}
+
+	$DataDefinition = New-Object PSObject -Property @{
+		DataCategoryName = $DataCategoryName
+		DataSetName = $DataSetName
+		DataSetNames = $DataSetNames
+	}
+	
+	if ($ColorScheme -eq "Generated") {$thisColorScheme = 'Generated' + [string](Get-Random -Minimum 1 -Maximum 8)}
+	elseif ($ColorScheme -eq "Random") {$thisColorScheme = 'Random' }
+	else {$thisColorScheme = 'ColorScheme2'}
+
+	$ChartStyle = New-Object PSObject -Property @{`
+		ChartType = $ChartType
+		ColorSchemeName = "$thisColorScheme"
+		Showlabels = $true
+		fill = $false
+		borderWidth = "1"
+		responsive = 'false'
+		animateScale = 'true'
+        animateRotate = 'true'
+		legendPosition = 'bottom'
+	}
+	
+	$ChartObject = New-Object PSObject -Property @{`
+		ObjectName = -join ((65..90) + (97..122) | Get-Random -Count 12 | ForEach-Object {[char]$_})
+		Title = ""
+		Size = $ChartSize
+		DataDefinition = $DataDefinition
+		ChartStyle = $ChartStyle
+	}
+	
+	return $ChartObject
+}


### PR DESCRIPTION
Solution for adding images and hyperlinks to reports. Below showcases how it would work

```
$ArrayOfObjects = New-Object 'System.Collections.Generic.List[System.Object]'
$obj = [PSCustomObject]@{
    param1 = [PSCustomObject]@{
        _type = 'img'
        src = 'http://ihavecat.com/wp-content/uploads/2014/01/cat-asking-for-help-2.jpg'
        alt = 'cat asking for help'
        width = 60
        height = 60
    }
    param2 = [PSCustomObject]@{
        _type = 'link'
        url = 'https://www.w3schools.com'
        target = '_blank'
        Content = 'Visit w3schools!'
    }
    param3 = 'simpleparam'
    param4 = [PSCustomObject]@{
        _type = 'link'
        url = 'http://ihavecat.com/wp-content/uploads/2014/01/cat-asking-for-help-2.jpg'
        target = '_blank'
        Content = [PSCustomObject]@{
            _type = 'img'
            src = 'http://ihavecat.com/wp-content/uploads/2014/01/cat-asking-for-help-2.jpg'
            alt = 'cat asking for help'
            width = 60
            height = 60
        }
    }
}
$ArrayOfObjects.Add($obj)
```
These 3 helper functions are used
```
Format-AnchorTag.ps1
Format-Html.ps1
Format-ImageTag.ps1
```
I updated `Get-HTMLContentTable.ps1` with the code needed to utilize these.

For line charts I added
```
Get-HTMLLineChartObject.ps1
Get-HTMLLineChart.ps1
```

You can see how that could work here [https://github.com/spaelling/PowerShellSpeedTest/blob/master/Loops.ps1](https://github.com/spaelling/PowerShellSpeedTest/blob/master/Loops.ps1)