### PR TITLE
New-HTMLTab - Add Text-Transform

### DIFF
--- a/Public/New-HTMLTab.ps1
+++ b/Public/New-HTMLTab.ps1
@@ -69,7 +69,7 @@ function New-HTMLTab {
         [parameter(ParameterSetName = "FontAwesomeBrands")]
         [parameter(ParameterSetName = "FontAwesomeRegular")]
         [parameter(ParameterSetName = "FontAwesomeSolid")][string] $IconColor,
-        [ValidateSet('uppercase', 'lowercase', 'capitalize')][string] $TextTransform  # New-HTMLTab - Add text-transform
+        [ValidateSet('uppercase', 'lowercase', 'capitalize')][string] $TextTransform = 'uppercase'  # New-HTMLTab - Add text-transform
     )
     if (-not $Script:HTMLSchema.Features) {
         Write-Warning 'New-HTMLTab - Creation of HTML aborted. Most likely New-HTML is missing.'
@@ -92,12 +92,7 @@ function New-HTMLTab {
         $StyleText.'color' = ConvertFrom-Color -Color $TextColor
     }
     # New-HTMLTab - Add text-transform
-    if($TextTransform){
-        $StyleText.'text-transform' = "$TextTransform"
-    }
-    else{
-        $StyleText.'text-transform' = "uppercase"
-    }
+    $StyleText.'text-transform' = "$TextTransform"
     # end
 
     $StyleIcon = @{ }


### PR DESCRIPTION
Added the `$TextTransform` parameter to the New-HTMLTab function to allow the text to be uppercase, lowercase or capitalized.

`New-HTMLTab -Name "Main" -IconRegular map -TextTransform capitalize {}`

![tab](https://user-images.githubusercontent.com/48139416/69349569-fb807d00-0c45-11ea-8d8f-4f68e98da5b0.JPG)

![capitalize](https://user-images.githubusercontent.com/48139416/69349568-fa4f5000-0c45-11ea-9700-16f7bb26c366.JPG)