### PR TITLE
Add -JustifyContent parameter to New-HTMLSection

### DIFF
--- a/Public/New-HTMLSection.ps1
+++ b/Public/New-HTMLSection.ps1
@@ -18,6 +18,7 @@ Function New-HTMLSection {
         [string][ValidateSet('row', 'row-reverse', 'column', 'column-reverse')] $Direction,
         [string][ValidateSet('flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'stretch')] $AlignContent,
         [string][ValidateSet('stretch', 'flex-start', 'flex-end', 'center', 'baseline')] $AlignItems
+        [string][ValidateSet('flex-start', 'flex-end', 'center')] $JustifyContent = 'flex-start' # Add $JustifyContent parameter and set default to flex-start
 
     )
     $RandomNumber = Get-Random
@@ -122,7 +123,7 @@ Function New-HTMLSection {
                 New-HTMLAnchor -Id "hide_$RandomNumber" -Href 'javascript:void(0)' -OnClick "hide('$RandomNumber');" -Style $HideStyle -Text '(Hide)'
             }
             New-HTMLTag -Tag 'div' -Attributes @{ class = $ClassName; id = $RandomNumber; Style = $HiddenDivStyle } -Value {
-                New-HTMLTag -Tag 'div' -Attributes @{ class = "$ClassName collapsable"; id = $RandomNumber; } -Value {
+                New-HTMLTag -Tag 'div' -Attributes @{ class = "$ClassName collapsable"; id = $RandomNumber; Style = "justify-content: $JustifyContent";  } -Value {
                     $Object = Invoke-Command -ScriptBlock $Content
                     if ($null -ne $Object) {
                         $Object

--- a/Public/New-HTMLSection.ps1
+++ b/Public/New-HTMLSection.ps1
@@ -18,7 +18,7 @@ Function New-HTMLSection {
         [string][ValidateSet('row', 'row-reverse', 'column', 'column-reverse')] $Direction,
         [string][ValidateSet('flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'stretch')] $AlignContent,
         [string][ValidateSet('stretch', 'flex-start', 'flex-end', 'center', 'baseline')] $AlignItems
-        [string][ValidateSet('flex-start', 'flex-end', 'center')] $JustifyContent = 'flex-start' # Add $JustifyContent parameter and set default to flex-start
+        [string][ValidateSet('flex-start', 'flex-end', 'center')] $JustifyContent
 
     )
     $RandomNumber = Get-Random
@@ -123,7 +123,7 @@ Function New-HTMLSection {
                 New-HTMLAnchor -Id "hide_$RandomNumber" -Href 'javascript:void(0)' -OnClick "hide('$RandomNumber');" -Style $HideStyle -Text '(Hide)'
             }
             New-HTMLTag -Tag 'div' -Attributes @{ class = $ClassName; id = $RandomNumber; Style = $HiddenDivStyle } -Value {
-                New-HTMLTag -Tag 'div' -Attributes @{ class = "$ClassName collapsable"; id = $RandomNumber; Style = "justify-content: $JustifyContent";  } -Value {
+                New-HTMLTag -Tag 'div' -Attributes @{ class = "$ClassName collapsable"; id = $RandomNumber; Style = @{'justify-content' = $JustifyContent} } -Value {
                     $Object = Invoke-Command -ScriptBlock $Content
                     if ($null -ne $Object) {
                         $Object


### PR DESCRIPTION
Adding the `-Justify Content` parameter will allow text in the section to be aligned to the left (flex-start), center (center) to right (flex-end).
This change will only work with text and serves as a good option for object counters in your sections.

![justify](https://user-images.githubusercontent.com/48139416/69577338-22b7b100-0f9c-11ea-8640-c29a87e5f571.JPG)

    New-HTML -TitleText "FST Monitor" -FilePath "$PSScriptRoot\Test-Dashboard.html" {

    # Text Section
        New-HTMLSection -HeaderText "Justify Content" {
            # Try to align text to the left - JustifyContent
            New-HTMLSection -HeaderText "Load Count" -JustifyContent flex-start {
                "100"
            }
            # Try to align text to center - Justify Content
            New-HTMLSection -HeaderText "Load Count" -JustifyContent center {
                "200"
            }
            # Try to align text to right - New-HTMLText
            New-HTMLSection -HeaderText "Load Count" -JustifyContent flex-end {
                "300"
            }
        }
    }
