### PR TITLE
Add a new try/catch for Access Denied error

### DIFF
--- a/Public/Save-HTML.ps1
+++ b/Public/Save-HTML.ps1
@@ -47,7 +47,16 @@ Function Save-HTML {
         }
     } catch {
         $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
-        Write-Warning "Save-HTML - Failed with error: $ErrorMessage"
+        $FilePath = Get-FileName -Temporary -Extension 'html'
+        Write-Warning "Save-HTML - Failed with error: $ErrorMessage`nSave-HTML - Saving HTML to file $FilePath"
+
+        Write-Verbose "Save-HTML - Saving HTML to file $FilePath"
+        try {
+            $HTML | Set-Content -LiteralPath $FilePath -Force -Encoding $Encoding
+        } catch{
+            $ErrorMessage = $_.Exception.Message -replace "`n", " " -replace "`r", " "
+            Write-Warning "Save-HTML - Failed with error: $ErrorMessage`nPlease define a different path for the `'-FilePath`' parameter."
+        }
     }
     if ($ShowHTML) {
         try {


### PR DESCRIPTION
Adding a new try/catch block to handle Access Denied errors for the  `-FilePath` parameter of `New-HTML`.
If there's an error, proceed to a new try and set the `$HTML` content, if there's another error, display a warning with the error.

![accessdenied](https://user-images.githubusercontent.com/48139416/69585881-ee012500-0fae-11ea-9081-6ca2d3d114e5.png)
