### PR TITLE
Adding Tab border customization and Tab header background color

### DIFF
--- a/Private/New-HTMLTabHead.ps1
+++ b/Private/New-HTMLTabHead.ps1
@@ -39,7 +39,7 @@ function New-HTMLTabHead {
     }
     New-HTMLTag -Tag 'div' -Attributes @{ class = 'tabsWrapper' } {
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'tabs' ; style = $Style } {
-            New-HTMLTag -Tag 'div' -Attributes @{ 'data-tabs' = 'true'; Style = $Script:BorderStyle } } {
+            New-HTMLTag -Tag 'div' -Attributes @{ 'data-tabs' = 'true'; Style = $Script:BorderStyle } {
                 foreach ($Tab in $Tabs) {
                     if ($Tab.Active) {
                         $TabActive = 'active'

--- a/Private/New-HTMLTabHead.ps1
+++ b/Private/New-HTMLTabHead.ps1
@@ -39,14 +39,14 @@ function New-HTMLTabHead {
     }
     New-HTMLTag -Tag 'div' -Attributes @{ class = 'tabsWrapper' } {
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'tabs' ; style = $Style } {
-            New-HTMLTag -Tag 'div' -Attributes @{ 'data-tabs' = 'true' } {
+            New-HTMLTag -Tag 'div' -Attributes @{ 'data-tabs' = 'true'; Style = $Script:BorderStyle } } {
                 foreach ($Tab in $Tabs) {
                     if ($Tab.Active) {
                         $TabActive = 'active'
                     } else {
                         $TabActive = ''
                     }
-                    New-HTMLTag -Tag 'div' -Attributes @{ id = $Tab.ID; class = $TabActive } {
+                    New-HTMLTag -Tag 'div' -Attributes @{ id = $Tab.ID; class = $TabActive; Style = @{'border-radius' = $Script:BorderStyle.'border-radius'}  } {
                         New-HTMLTag -Tag 'div' -Attributes @{ class = $($Tab.Icon); style = $($Tab.StyleIcon) }
                         New-HTMLTag -Tag 'span' -Attributes @{ style = $($Tab.StyleText ) } -Value { $Tab.Name }
                     }

--- a/Public/New-HTMLTabOptions.ps1
+++ b/Public/New-HTMLTabOptions.ps1
@@ -6,7 +6,9 @@
         [string] $SelectorColor,
         [string] $SelectorColorTarget,
         [switch] $Transition,
-        [switch] $LinearGradient
+        [switch] $LinearGradient,
+        [ValidateSet('0px','10px','15px','25px')][string] $BorderRadius = '0px',
+        [string] $BorderBackgroundColor
 
     )
     if (-not $Script:HTMLSchema) {
@@ -27,7 +29,17 @@
     }
     $Script:HTMLSchema.Features.TabbisGradient = $LinearGradient.IsPresent
     $Script:HTMLSchema.Features.TabbisTransition = $Transition.IsPresent
+    
+    $Script:BorderStyle = @{
+        'border-radius' = "$BorderRadius";
+        'background-color' = ""
+    }
+
+    if($BorderBackgroundColor){
+        $Script:BorderStyle.'background-color' = ConvertFrom-Color -Color $BorderBackgroundColor
+    }
 }
 
 Register-ArgumentCompleter -CommandName New-HTMLTabOptions -ParameterName SelectorColor -ScriptBlock { $Script:RGBColors.Keys }
 Register-ArgumentCompleter -CommandName New-HTMLTabOptions -ParameterName SelectorColorTarget -ScriptBlock { $Script:RGBColors.Keys }
+Register-ArgumentCompleter -CommandName New-HTMLTabOptions -ParameterName BorderBackgroundColor -ScriptBlock { $Script:RGBColors.Keys }


### PR DESCRIPTION
Parameters added to `New-HTMLTabOptions`:
* Added the `-BorderRadius` parameter with four options to customize the tab border style (0px, 10px, 15px, 25px) from square to more rounded borders.

* Added the `-BorderBackgroundColor` parameter to customize the tab header background color.

* Added the `$Script:BorderStyle` variable to the `New-HTMLTabHead` to apply the styles.

`New-HTMLTabOptions  -SelectorColor Blue -BorderRadius 0px -BorderBackgroundColor LightBlue`

![0px](https://user-images.githubusercontent.com/48139416/69666201-e21e6d00-1059-11ea-913f-e2ef1e6aedae.JPG)

`New-HTMLTabOptions -SelectorColor Blue -BorderRadius 10px -BorderBackgroundColor LightBlue`

![10px](https://user-images.githubusercontent.com/48139416/69666208-e3e83080-1059-11ea-86bb-67b2ae8b67fd.JPG)

`New-HTMLTabOptions -SelectorColor Blue -BorderRadius 15px -BorderBackgroundColor LightBlue`

![15px](https://user-images.githubusercontent.com/48139416/69666210-e5b1f400-1059-11ea-951f-628c86493d10.JPG)

`New-HTMLTabOptions -SelectorColor Blue -BorderRadius 25px -BorderBackgroundColor LightBlue`

![25px](https://user-images.githubusercontent.com/48139416/69666216-e6e32100-1059-11ea-9b99-022e5bb7b2a3.JPG)

`New-HTMLTabOptions -SlimTabs -SelectorColor Blue -BorderRadius 25px -BorderBackgroundColor LightBlue`

![slim](https://user-images.githubusercontent.com/48139416/69666219-e8144e00-1059-11ea-8b35-bf2a65fa0a86.JPG)
