### PR TITLE
Table Conditional Formatting for Date Strings

### DIFF
--- a/Private/Tables/New-TableConditionalFormatting.ps1
+++ b/Private/Tables/New-TableConditionalFormatting.ps1
@@ -46,7 +46,16 @@ function New-TableConditionalFormatting {
                         }
                     }
                 } elseif ($Condition.Type -eq 'date') {
-                    "if (new Date(data[$ConditionHeaderNr]) $($Condition.Operator) new Date('$($Condition.Value)')) {"
+                    switch($Condition.Operator){
+                        {$_ -eq "==" -or $_ -eq "!="} {
+                            $Condition.Type = 'string'
+                            "if ((data[$ConditionHeaderNr]) $($Condition.Operator) ('$($Condition.Value)')) {"
+                        }
+                        default {
+                            $Condition.Type = 'date'
+                            "if (new Date(data[$ConditionHeaderNr]) $($Condition.Operator) new Date('$($Condition.Value)')) {"
+                        }
+                    }   
                 }
                 if ($null -ne $Condition.Row -and $Condition.Row -eq $true) {
                     "`$(column)$($StyleDefinition);"

--- a/Public/New-TableCondition.ps1
+++ b/Public/New-TableCondition.ps1
@@ -3,7 +3,7 @@ function New-TableCondition {
     [CmdletBinding()]
     param(
         [alias('ColumnName')][string] $Name,
-        [alias('Type')][ValidateSet('number', 'string')][string] $ComparisonType,
+        [alias('Type')][ValidateSet('number', 'string', 'date')][string] $ComparisonType,
         [ValidateSet('lt', 'le', 'eq', 'ge', 'gt', 'ne', 'contains', 'like')][string] $Operator,
         [Object] $Value,
         [switch] $Row,


### PR DESCRIPTION
Added a switch to handle the comparison for date strings inside the `elseif` for date.
Added `date` to the `$ComparisonType` validate set.
When using the `eq` and `ne`, it's going to use strings to compare. The value that's used to compare to the table must be the same, otherwise it won't be able to find it is equal/not equal. 
(Eg: Table value = 12/1/2019 10:00 AM; `-Value "12/1/2019 10:00 AM"`). 
For the other operators it will use date.

![dateCompare](https://user-images.githubusercontent.com/48139416/70178088-9a2ac600-16a9-11ea-8e88-d9dde21b6879.png)


    $Table = @()
    $Table = 0..5 | ForEach-Object { [PSCustomObject] @{
            "Name" = (Get-RandomStringName -LettersOnly -Size 5)
            "Date" = (Get-Date).AddDays("-" + $(Get-Random -Minimum 1 -Maximum 10))
        }
    }

    $Table2 = @()
    $Table2 = 0..5 | ForEach-Object { [PSCustomObject] @{
            "Name" = (Get-RandomStringName -LettersOnly -Size 5)
            "Date" = ((Get-Date).AddDays("-" + $(Get-Random -Minimum 1 -Maximum 10))).ToString("MM/dd/yyyy")
        }
    }

    $Value = $Table[(Get-Random -Minimum 0 -Maximum ($Table.Count - 1))].Date.ToString("MM/dd/yyyy h:mm:ss tt")
    $Value2 = $Table2[(Get-Random -Minimum 0 -Maximum ($Table2.Count - 1))].Date


    New-HTML -TitleText "test" -FilePath "$PSScriptRoot\test.html" {

        New-HTMLSection -Invisible -Content { 

            New-HTMLSection -HeaderText "Less than: $Value" -Content {
                New-HTMLTable -DataTable $Table {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator lt -Value $Value -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Greater than: $Value" -Content {
                New-HTMLTable -DataTable $Table {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator gt -Value $Value -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Less than or equal: $Value" -Content {
                New-HTMLTable -DataTable $Table {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator le -Value $Value -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Greater than or equal: $Value" -Content {
                New-HTMLTable -DataTable $Table {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator ge -Value $Value -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Equal: $Value" -Content {     
                New-HTMLTable -DataTable $Table {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator eq -Value $Value -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Not Equal: $Value" -Content {
                New-HTMLTable -DataTable $Table {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator ne -Value $Value -BackgroundColor LightBlue
                }        
            }
        }

        New-HTMLSection -Invisible -Content { 

            New-HTMLSection -HeaderText "Less than: $Value2" -Content {
                New-HTMLTable -DataTable $Table2 {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator lt -Value $Value2 -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Greater than: $Value2" -Content {
                New-HTMLTable -DataTable $Table2 {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator gt -Value $Value2 -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Less than or equal: $Value2" -Content {
                New-HTMLTable -DataTable $Table2 {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator le -Value $Value2 -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Greater than or equal: $Value2" -Content {
                New-HTMLTable -DataTable $Table2 {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator ge -Value $Value2 -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Equal: $Value2" -Content {     
                New-HTMLTable -DataTable $Table2 {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator eq -Value $Value2 -BackgroundColor LightBlue
                }
            }
            New-HTMLSection -HeaderText "Not Equal: $Value2" -Content {
                New-HTMLTable -DataTable $Table2 {
                    New-HTMLTableCondition -Name "Date" -ComparisonType date -Operator ne -Value $Value2 -BackgroundColor LightBlue
                }        
            }
        }
    }


