### PR TITLE
New-HTMLStatusItem customization

### DIFF
--- a/Public/New-HTMLStatusItem.ps1
+++ b/Public/New-HTMLStatusItem.ps1
@@ -1,73 +1,135 @@
 function New-HTMLStatusItem {
-    [CmdletBinding(DefaultParameterSetName = 'Percent')]
+    [CmdletBinding(DefaultParameterSetName = 'Statusimo')]
     param(
         [string] $ServiceName,
-
         [string] $ServiceStatus,
 
         [ValidateSet('Dead', 'Bad', 'Good')]
-        [string]$Icon = 'Good',
+        [Parameter(ParameterSetName = 'Statusimo')]
+        $Icon = 'Good',
 
         [ValidateSet('0%', '10%', '30%', '70%', '100%')]
-        [Parameter(ParameterSetName = 'Percent')]
-        [string]$Percentage = '100%',
+        [Parameter(ParameterSetName = 'Statusimo')]
+        [string] $Percentage = '100%',
 
-        [ValidatePattern('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')]
-        [Parameter(ParameterSetName = 'Hex')]
-        [string]$BackgroundColor,
-
-        [ValidatePattern('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')]
         [string]$FontColor = '#5f6982',
 
-        [ValidatePattern('^&#x[A-Fa-f0-9]{4,5}')]
+        [parameter(ParameterSetName = 'FontAwesomeBrands')]
+        [parameter(ParameterSetName = 'FontAwesomeRegular')]
+        [parameter(ParameterSetName = "FontAwesomeSolid")]
+        [Parameter(ParameterSetName = 'Hex')]
+        [string]$BackgroundColor = '#0ef49b',
+
+        # ICON BRANDS
+        [ArgumentCompleter(
+            {
+                param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+                ($Global:HTMLIcons.FontAwesomeBrands.Keys)
+            }
+        )]
+        [ValidateScript(
+            {
+                $_ -in (($Global:HTMLIcons.FontAwesomeBrands.Keys))
+            }
+        )]
+        [parameter(ParameterSetName = 'FontAwesomeBrands')]
+        [string] $IconBrands,
+
+        # ICON REGULAR
+        [ArgumentCompleter(
+            {
+                param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+                ($Global:HTMLIcons.FontAwesomeRegular.Keys)
+            }
+        )]
+        [ValidateScript(
+            {
+                $_ -in (($Global:HTMLIcons.FontAwesomeRegular.Keys))
+            }
+        )]
+        [parameter(ParameterSetName = 'FontAwesomeRegular')]
+        [string] $IconRegular,
+
+        # ICON SOLID
+        [ArgumentCompleter(
+            {
+                param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+                ($Global:HTMLIcons.FontAwesomeSolid.Keys)
+            }
+        )]
+        [ValidateScript(
+            {
+                $_ -in (($Global:HTMLIcons.FontAwesomeSolid.Keys))
+            }
+        )]
+        [parameter(ParameterSetName = 'FontAwesomeSolid')]
+        [string] $IconSolid,
+
+        [Parameter(ParameterSetName = 'Hex')]
+        [ValidatePattern('^&#x[A-Fa-f0-9]{4,5}$')]
         [string]$IconHex
     )
     #$Script:HTMLSchema.Features.StatusButtonical = $true
-    if ($IconHex) {
-        $IconType = $IconHex
-    }
-    else {
+    if ($PSCmdlet.ParameterSetName -eq 'Statusimo') {
+        Write-Warning 'This parameter set has been deprecated. It will be removed in a future release. Look to move to the other parameter sets with customization options.'
+
+        if ($Percentage -eq '100%') {
+            $BackgroundColor = '#0ef49b'
+        } elseif ($Percentage -eq '70%') {
+            $BackgroundColor = '#d2dc69'
+        } elseif ($Percentage -eq '30%') {
+            $BackgroundColor = '#faa04b'
+        } elseif ($Percentage -eq '10%') {
+            $BackgroundColor = '#ff9035'
+        } elseif ($Percentage -eq '0%') {
+            $BackgroundColor = '#ff5a64'
+        }
+
         if ($Icon -eq 'Dead') {
             $IconType = '&#x2620'
-        } elseif ($Icon -eq 'Bad') {
+        }
+        elseif ($Icon -eq 'Bad') {
             $IconType = '&#x2639'
-        } elseif ($Icon -eq 'Good') {
+        }
+        elseif ($Icon -eq 'Good') {
             $IconType = '&#x2714'
         }
     }
+    elseif ($PSCmdlet.ParameterSetName -like 'FontAwesome*') {
+        $BackgroundColor = Convert-FromColor -Color $BackgroundColor
 
-    if ($PSCmdlet.ParameterSetName -eq 'Percent') {
-        if ($Percentage -eq '100%') {
-            $Colors = 'background-color: #0ef49b;'
-        } elseif ($Percentage -eq '70%') {
-            $Colors = 'background-color: #d2dc69;'
-        } elseif ($Percentage -eq '30%') {
-            $Colors = 'background-color: #faa04b;'
-        } elseif ($Percentage -eq '10%') {
-            $Colors = 'background-color: #ff9035;'
-        } elseif ($Percentage -eq '0%') {
-            $Colors = 'background-color: #ff5a64;'
+        if ($IconBrands) {
+            $IconClass = "fab fa-$IconBrands"
+        }
+        elseif ($IconRegular) {
+            $IconClass = "far fa-$IconRegular"
+        }
+        elseif ($IconSolid) {
+            $IconClass = "fas fa-$IconSolid"
         }
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Hex') {
-        $Colors = "background-color: $BackgroundColor;"
+        $IconType = $IconHex
     }
+    $FontColor = Convert-FromColor -Color $FontColor
 
-    New-HTMLTag -Tag 'div' -Attributes @{ class = 'buttonical'; style = $Colors } -Value {
+    New-HTMLTag -Tag 'div' -Attributes @{ class = 'buttonical'; style = "background-color: $BackgroundColor" } -Value {
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'label' } {
-            New-HTMLTag -Tag 'span' -Attributes @{ class = 'performance'; style = "color: $FontColor" } {
+            New-HTMLTag -Tag 'span' -Attributes @{ class = 'performance'; style = "color: $FontColor"} {
                 $ServiceName
             }
         }
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'middle' }
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'status'} {
             New-HTMLTag -Tag 'input' -Attributes @{ name = Get-Random; type = 'radio'; value = 'other-item'; checked = 'true' } -SelfClosing
-            New-HTMLTag -Tag 'span' -Attributes @{ class = 'performance'; style = "color: $FontColor" } {
+            New-HTMLTag -Tag 'span' -Attributes @{ class = "performance"; style = "color: $FontColor" } {
                 $ServiceStatus
-                New-HTMLTag -Tag 'span' -Attributes @{ class = 'icon' } {
+                New-HtmlTag -Tag 'span' -Attributes @{ class = "icon $IconClass" } {
                     $IconType
                 }
             }
         }
     }
 }
+Register-ArgumentCompleter -CommandName New-HTMLStatusItem -ParameterName FontColor -ScriptBlock { $Script:RGBColors.Keys }
+Register-ArgumentCompleter -CommandName New-HTMLStatusItem -ParameterName BackgroundColor -ScriptBlock { $Script:RGBColors.Keys }

--- a/Public/New-HTMLStatusItem.ps1
+++ b/Public/New-HTMLStatusItem.ps1
@@ -1,43 +1,72 @@
 function New-HTMLStatusItem {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Percent')]
     param(
         [string] $ServiceName,
+
         [string] $ServiceStatus,
-        [ValidateSet('Dead', 'Bad', 'Good')]$Icon = 'Good',
-        [ValidateSet('0%', '10%', '30%', '70%', '100%')][string] $Percentage = '100%'
+
+        [ValidateSet('Dead', 'Bad', 'Good')]
+        [string]$Icon = 'Good',
+
+        [ValidateSet('0%', '10%', '30%', '70%', '100%')]
+        [Parameter(ParameterSetName = 'Percent')]
+        [string]$Percentage = '100%',
+
+        [ValidatePattern('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')]
+        [Parameter(ParameterSetName = 'Hex')]
+        [string]$BackgroundColor,
+
+        [ValidatePattern('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')]
+        [string]$FontColor = '#5f6982',
+
+        [ValidatePattern('^&#x[A-Fa-f0-9]{4,5}')]
+        [string]$IconHex
     )
     #$Script:HTMLSchema.Features.StatusButtonical = $true
-    if ($Icon -eq 'Dead') {
-        $IconType = 'performanceDead'
-    } elseif ($Icon -eq 'Bad') {
-        $IconType = 'performanceProblem'
-    } elseif ($Icon -eq 'Good') {
-        #$IconType = 'performance'
+    if ($IconHex) {
+        $IconType = $IconHex
+    }
+    else {
+        if ($Icon -eq 'Dead') {
+            $IconType = '&#x2620'
+        } elseif ($Icon -eq 'Bad') {
+            $IconType = '&#x2639'
+        } elseif ($Icon -eq 'Good') {
+            $IconType = '&#x2714'
+        }
     }
 
-    if ($Percentage -eq '100%') {
-        $Colors = 'background-color: #0ef49b;'
-    } elseif ($Percentage -eq '70%') {
-        $Colors = 'background-color: #d2dc69;'
-    } elseif ($Percentage -eq '30%') {
-        $Colors = 'background-color: #faa04b;'
-    } elseif ($Percentage -eq '10%') {
-        $Colors = 'background-color: #ff9035;'
-    } elseif ($Percentage -eq '0%') {
-        $Colors = 'background-color: #ff5a64;'
+    if ($PSCmdlet.ParameterSetName -eq 'Percent') {
+        if ($Percentage -eq '100%') {
+            $Colors = 'background-color: #0ef49b;'
+        } elseif ($Percentage -eq '70%') {
+            $Colors = 'background-color: #d2dc69;'
+        } elseif ($Percentage -eq '30%') {
+            $Colors = 'background-color: #faa04b;'
+        } elseif ($Percentage -eq '10%') {
+            $Colors = 'background-color: #ff9035;'
+        } elseif ($Percentage -eq '0%') {
+            $Colors = 'background-color: #ff5a64;'
+        }
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq 'Hex') {
+        $Colors = "background-color: $BackgroundColor"
     }
 
     New-HTMLTag -Tag 'div' -Attributes @{ class = 'buttonical'; style = $Colors } -Value {
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'label' } {
-            New-HTMLTag -Tag 'span' -Attributes @{ class = 'performance' } {
+            New-HTMLTag -Tag 'span' -Attributes @{ class = 'performance'; style = "color: $FontColor" } {
                 $ServiceName
             }
         }
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'middle' }
         New-HTMLTag -Tag 'div' -Attributes @{ class = 'status'} {
             New-HTMLTag -Tag 'input' -Attributes @{ name = Get-Random; type = 'radio'; value = 'other-item'; checked = 'true' } -SelfClosing
-            New-HTMLTag -Tag 'span' -Attributes @{ class = "performance $IconType" } {
+            New-HTMLTag -Tag 'span' -Attributes @{ class = 'performance'; style = "color: $FontColor" } {
                 $ServiceStatus
+                New-HTMLTag -Tag 'span' -Attributes @{ class = 'icon' } {
+                    $IconType
+                }
             }
         }
     }

--- a/Public/New-HTMLStatusItem.ps1
+++ b/Public/New-HTMLStatusItem.ps1
@@ -50,7 +50,7 @@ function New-HTMLStatusItem {
         }
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Hex') {
-        $Colors = "background-color: $BackgroundColor"
+        $Colors = "background-color: $BackgroundColor;"
     }
 
     New-HTMLTag -Tag 'div' -Attributes @{ class = 'buttonical'; style = $Colors } -Value {

--- a/Resources/CSS/status.css
+++ b/Resources/CSS/status.css
@@ -72,5 +72,5 @@
 	margin-left: 12px;
 	display: inline-block;
 	-webkit-transform: scale(1.35);
-	transform: scale(1.35;
+	transform: scale(1.35);
 }

--- a/Resources/CSS/status.css
+++ b/Resources/CSS/status.css
@@ -17,12 +17,9 @@
     box-shadow: 0 2px 4px -1px rgba(25, 25, 25, 0.2);
 }
 
-
 .buttonical input {
     display: none;
 }
-
-
 
 .buttonical .label {
     display: table;
@@ -61,31 +58,6 @@
     display: table-cell;
     vertical-align: middle;
     font-weight: 300;
-    color: #fff;
-}
-
-.buttonical .performance:after {
-    content: "\2714";
-    margin-left: -10px;
-    display: inline-block;
-    -webkit-transform: scale(0);
-    transform: scale(0);
-}
-
-.buttonical .performanceProblem:after {
-    content: "\2639";
-    margin-left: -10px;
-    display: inline-block;
-    -webkit-transform: scale(0);
-    transform: scale(0);
-}
-
-.buttonical .performanceDead:after {
-    content: "\2620";
-    margin-left: -10px;
-    display: inline-block;
-    -webkit-transform: scale(0);
-    transform: scale(0);
 }
 
 .buttonical .first {
@@ -96,12 +68,9 @@
     border-radius: 0 40px 40px 0;
 }
 
-.buttonical input:checked+.performance {
-    color: #5f6982;
-}
-
-.buttonical input:checked+.performance:after {
-    margin-left: 12px;
-    -webkit-transform: scale(1.25);
-    transform: scale(1.25);
+.buttonical .icon {
+	margin-left: 12px;
+	display: inline-block;
+	-webkit-transform: scale(1.35);
+	transform: scale(1.35;
 }


### PR DESCRIPTION
Modifications leave all original functionality and syntax in working order. 

- Added functionality to customize the background color of the status items using color hex codes. ('#5f6982')
- Added functionality to customize the font color of the service status and name using color hex codes. ('#5f6982')
- Added functionality to customize icons to any HTML icon that has a hex code consisting of 4 or 5 digits. ('&#x2620')
- Removed CSS classes from status.css that are no longer needed.
- Added CSS class 'icon' to handle formatting of the icons as the old classes did.