### PR TITLE
Fix TempFilePath using System.IO.Path

### DIFF
--- a/Public/Email.ps1
+++ b/Public/Email.ps1
@@ -109,7 +109,7 @@ function Email {
     }
     if ($AttachSelf) {
         if ($AttachSelfName) {
-            $TempFilePath = "$(Get-TemporaryDirectory)\$($AttachSelfName).html"
+            $TempFilePath = [System.IO.Path]::Combine($(Get-TemporaryDirectory), "$($AttachSelfName).html")
         } else {
             $TempFilePath = ''
         }


### PR DESCRIPTION
The hardcoded backslash in the pathing for the $TempFilePath created for $AttachSelfName will fail on MacOS and Linux. [System.IO.Path]::Combine solves this.