### PR TITLE
Update New-HTMLText.ps1

### DIFF
--- a/Examples/Example-Texts/Example-Texts01.ps1
+++ b/Examples/Example-Texts/Example-Texts01.ps1
@@ -13,4 +13,9 @@ New-HTML -TitleText 'My title' -Online -FilePath $PSScriptRoot\Example-Texts01.h
         New-HTMLListItem -Text '[Link2](https://evotec.xyz) SomeText'
         New-HTMLListItem -Text '[Link2](https://evotec.xyz) SomeText (TestingText in brackets) and more [more test in brackets] (and more)'
     }
+    New-HTMLText -Text @(
+        "This is a string with [SomeURL](https://evotec.xyz) and this isn't. "
+        "This is more complicated [URL](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/dn535495(v=ws.11)) with double () and it doesn't work properly "
+        "More URLs in one line  [SomeURL](https://evotec.xyz) and and [SomeURL](https://evotec.xyz)."
+    )
 }

--- a/Public/New-HTMLText.ps1
+++ b/Public/New-HTMLText.ps1
@@ -137,11 +137,11 @@ function New-HTMLText {
 
         $newSpanTextSplat.LineBreak = $LineBreak
         New-HTMLSpanStyle @newSpanTextSplat {
-            $FindMe = [regex]::Matches($Text[$i], "\[[^\]]+\]\([^)]+\)")
+            $FindMe = [regex]::Matches($Text[$i], "\[[^\]]+\]\(\S+\)")
             if ($FindMe) {
                 foreach ($find in $FindMe) {
                     $LinkName = ([regex]::Match($Find.value, "[^\[]+(?=\])")).Value
-                    $LinkURL = ([regex]::Match($Find.value, "(?<=\().+?(?=\))")).Value
+                    $LinkURL = ([regex]::Match($Find.value, "(?<=\().+(?=\))")).Value
                     $Link = New-HTMLAnchor -HrefLink $LinkURL -Text $LinkName
                     $Text[$i] = $Text[$i].Replace($find.value, $Link)
                 }


### PR DESCRIPTION
Removed ")" exclusion from $FindMe - any string in [text]\(url) format should now match, regardless of number of brackets in url.

No longer require lazy matching for $LinkURL - it should always end in ")" which can then be excluded.

Should fix #200