### PR TITLE
Feature/add tree view autosize

### DIFF
--- a/Public/New-HTMLHierarchicalTree.ps1
+++ b/Public/New-HTMLHierarchicalTree.ps1
@@ -1,7 +1,8 @@
 ﻿function New-HTMLHierarchicalTree {
     [cmdletBinding()]
     param(
-        [ScriptBlock] $TreeView
+        [ScriptBlock] $TreeView,
+		[Switch]$Autosize
     )
     $Script:HTMLSchema.Features.MainFlex = $true
     $Script:HTMLSchema.Features.D3Mitch = $true
@@ -19,6 +20,13 @@
 
     # Prepare NODES
     $Data = $TreeNodes | ConvertTo-Json -Depth 5
+
+	# Set sizing mode
+	if ($Autosize) {
+		$SizingMode = 'nodeSize'	# Size the SVG based on the nodes
+	} else {
+		$SizingMode = 'size'		# Use configured height/width for the SVG
+	}
 
     # Prepare HTML
     $Section = New-HTMLTag -Tag 'section' -Attributes @{ id = $ID; class = 'hierarchicalTree' }
@@ -40,6 +48,9 @@
         .setTitleDisplayTextAccessor(function (data) {
             return data.name;
         })
+		.getNodeSettings()
+			.setSizingMode('${SizingMode}')
+			.back()
         .initialize();
 "@
     } -NewLine

--- a/Public/New-HTMLHierarchicalTree.ps1
+++ b/Public/New-HTMLHierarchicalTree.ps1
@@ -2,7 +2,7 @@
     [cmdletBinding()]
     param(
         [ScriptBlock] $TreeView,
-		[Switch]$Autosize
+        [Switch]$Autosize
     )
     $Script:HTMLSchema.Features.MainFlex = $true
     $Script:HTMLSchema.Features.D3Mitch = $true
@@ -21,12 +21,12 @@
     # Prepare NODES
     $Data = $TreeNodes | ConvertTo-Json -Depth 5
 
-	# Set sizing mode
-	if ($Autosize) {
-		$SizingMode = 'nodeSize'	# Size the SVG based on the nodes
-	} else {
-		$SizingMode = 'size'		# Use configured height/width for the SVG
-	}
+    # Set sizing mode
+    if ($Autosize) {
+        $SizingMode = 'nodeSize'  # Size the SVG based on the nodes
+    } else {
+        $SizingMode = 'size'      # Use configured height/width for the SVG
+    }
 
     # Prepare HTML
     $Section = New-HTMLTag -Tag 'section' -Attributes @{ id = $ID; class = 'hierarchicalTree' }
@@ -48,9 +48,9 @@
         .setTitleDisplayTextAccessor(function (data) {
             return data.name;
         })
-		.getNodeSettings()
-			.setSizingMode('${SizingMode}')
-			.back()
+        .getNodeSettings()
+            .setSizingMode('${SizingMode}')
+            .back()
         .initialize();
 "@
     } -NewLine


### PR DESCRIPTION
Add an `-Autosize` option to `New-HTMLHierarchicalTree` for large datasets

When displaying larger datasets with the tree view the default display mode leads to overlapping boxes and obscured data.  The `-Autosize` switch allows use of the `nodeSize` sizing mode which expands the view to fit the data.