### PR TITLE
Fix case-sensitivity for ChangeLog in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Dependencies: **PSSharedGoods**, **PSWriteColor** and **Connectimo** are only us
 
 `PSWriteHTML` undergoes changes that hopefully will make it more versalite, consistent and better.
 Please make sure to read changes before updating, as we're undergoing some breaking changes from time to time.
-Full **changelog** can be found [here](ChangeLog.md).
+Full **changelog** can be found [here](CHANGELOG.MD).
 
 ## Advantages over ReportHTML
 


### PR DESCRIPTION
## Updates 'ChangeLog' case-sensitivity in readme to match 'CHANGELOG.MD' filename

### Before
- Directs to using `https://github.com/EvotecIT/PSWriteHTML/blob/master/ChangeLog.md`
![2024-07-09_1123](https://github.com/EvotecIT/PSWriteHTML/assets/66083310/ed640cf7-d9f5-40ad-8186-75c62b658438)

### After
- Direct to `https://github.com/EvotecIT/PSWriteHTML/blob/master/CHANGELOG.MD`
![2024-07-09_1124](https://github.com/EvotecIT/PSWriteHTML/assets/66083310/ce4f00e1-8b9b-4809-a37f-69f271ab2495)
