### PR TITLE
fixed Get-HTMLLogos missing $LogoPath

### DIFF
--- a/Private/Get-HTMLLogos.ps1
+++ b/Private/Get-HTMLLogos.ps1
@@ -29,6 +29,7 @@ Function Get-HTMLLogos {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]
+        [string]$LogoPath,
         [string]$LeftLogoName = "Sample",
         [string]$RightLogoName = "Alternate",
         [string]$LeftLogoString,
@@ -36,18 +37,20 @@ Function Get-HTMLLogos {
 
     )
     $LogoSources = [ordered] @{ }
-    $LogoPath = @(
-        if ([String]::IsNullOrEmpty($RightLogoString) -eq $false -or [String]::IsNullOrEmpty($LeftLogoString) -eq $false) {
-            if ([String]::IsNullOrEmpty($RightLogoString) -eq $false) {
-                $LogoSources.Add($RightLogoName, $RightLogoString)
+    if ([String]::IsNullOrEmpty($LogoPath)) {
+        $LogoPath = @(
+            if ([String]::IsNullOrEmpty($RightLogoString) -eq $false -or [String]::IsNullOrEmpty($LeftLogoString) -eq $false) {
+                if ([String]::IsNullOrEmpty($RightLogoString) -eq $false) {
+                    $LogoSources.Add($RightLogoName, $RightLogoString)
+                }
+                if ([String]::IsNullOrEmpty($LeftLogoString) -eq $false) {
+                    $LogoSources.Add($LeftLogoName, $LeftLogoString)
+                }
+            } else {
+                "$PSScriptRoot\..\Resources\Images\Other"
             }
-            if ([String]::IsNullOrEmpty($LeftLogoString) -eq $false) {
-                $LogoSources.Add($LeftLogoName, $LeftLogoString)
-            }
-        } else {
-            "$PSScriptRoot\..\Resources\Images\Other"
-        }
-    )
+        )
+    }
     $ImageFiles = Get-ChildItem -Path (Join-Path $LogoPath '\*') -Include *.jpg, *.png, *.bmp -Recurse
     foreach ($ImageFile in $ImageFiles) {
         $ImageBinary = Convert-ImageToBinary -ImageFile $ImageFile

--- a/Private/Get-HTMLLogos.ps1
+++ b/Private/Get-HTMLLogos.ps1
@@ -6,6 +6,9 @@ Function Get-HTMLLogos {
     .DESCRIPTION
     This function retrieves HTML logos from specified paths and converts them to binary format. It allows for customization of left and right logos with default names "Sample" and "Alternate" respectively.
 
+    .PARAMETER LogoPath
+    The path to the logos. Default is not set.
+
     .PARAMETER LeftLogoName
     The name of the left logo. Default is "Sample".
 

--- a/Public/New-HTMLLogo.ps1
+++ b/Public/New-HTMLLogo.ps1
@@ -46,7 +46,7 @@ function New-HTMLLogo {
     )
     $Script:HTMLSchema.Features.MainImage = $true
 
-    $LogoSources = Get-HTMLLogos -RightLogoName $RightLogoName -LeftLogoName $LeftLogoName -LeftLogoString $LeftLogoString -RightLogoString $RightLogoString
+    $LogoSources = Get-HTMLLogos -LogoPath $LogoPath -RightLogoName $RightLogoName -LeftLogoName $LeftLogoName -LeftLogoString $LeftLogoString -RightLogoString $RightLogoString
 
     $Options = [PSCustomObject] @{
         Logos        = $LogoSources


### PR DESCRIPTION
Hi Przemysław,
the LogoPath parameter seemed to be missing for "Get-HTMLLogos" to be able to use logos as binary from custom locations.
I added a few lines to make it work for our use case and wanted to provide that to you.
Greetings,
Fabian